### PR TITLE
fix: fix dataSlot computation on btor()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The contract also includes a conversion function `rtob(ray)` that calculates the
 
 - **5000bps Ethereum Mainnet**: 0xea91A18dAFA1Cb1d2a19DFB205816034e6Fe7e52
 
-**Note**: The Mainnet deployment above contains a bug fixed in [c831a6b](https://github.com/sky-ecosystem/rates-conv/pull/4/commits/c831a6bf4566d150d79ade12ac1f532da62940bc). The bug does not affect the contract, but for future deployments the fixed version should be used.
+**Note**: The Mainnet deployment above contains a bug fixed in [PR #4](https://github.com/sky-ecosystem/rates-conv/pull/4), that would cause calls to the contract to fail if RATES storage slot is not 0. This does not affect the deployed contract (the storage layout cannot change after deployment) but future deployments should favor fixed version. For full details on the issue check [PR #4](https://github.com/sky-ecosystem/rates-conv/pull/4).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The contract also includes a conversion function `rtob(ray)` that calculates the
 
 - **5000bps Ethereum Mainnet**: 0xea91A18dAFA1Cb1d2a19DFB205816034e6Fe7e52
 
+**Note**: The Mainnet deployment above contains a bug fixed in [c831a6b](https://github.com/sky-ecosystem/rates-conv/pull/4/commits/c831a6bf4566d150d79ade12ac1f532da62940bc). The bug does not affect the contract, but for future deployments the fixed version should be used.
+
 ## Usage
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The contract also includes a conversion function `rtob(ray)` that calculates the
 
 - **5000bps Ethereum Mainnet**: 0xea91A18dAFA1Cb1d2a19DFB205816034e6Fe7e52
 
-**Note**: The Mainnet deployment above contains a bug fixed in [PR #4](https://github.com/sky-ecosystem/rates-conv/pull/4), that would cause calls to the contract to fail if RATES storage slot is not 0. This does not affect the deployed contract (the storage layout cannot change after deployment) but future deployments should favor fixed version. For full details on the issue check [PR #4](https://github.com/sky-ecosystem/rates-conv/pull/4).
+**Note**: The Mainnet deployment above contains a bug fixed in [PR #4](https://github.com/sky-ecosystem/rates-conv/pull/4), that would cause calls to the contract to fail if RATES storage slot is not 0. This does not affect the deployed contract (the storage layout cannot change after deployment) but future deployments should favor the fixed version.
 
 ## Usage
 

--- a/src/Conv.sol
+++ b/src/Conv.sol
@@ -44,9 +44,12 @@ contract Conv {
         (uint256 wordPos, uint256 bytePos) = (offset / 32, offset % 32);
 
         bytes32 value;
-        assembly {
-            let dataSlot := keccak256(RATES.slot, 0x20)
+        assembly ("memory-safe") {
+            let free_mem_ptr := mload(0x40)
+            mstore(free_mem_ptr, RATES.slot)
+            let dataSlot := keccak256(free_mem_ptr, 0x20)
             value := sload(add(dataSlot, wordPos))
+            mstore(0x40, add(free_mem_ptr, 0x20))
         }
 
         uint256 shifted = uint256(value) >> ((24 - bytePos) * 8);

--- a/src/Conv.sol
+++ b/src/Conv.sol
@@ -45,11 +45,12 @@ contract Conv {
 
         bytes32 value;
         assembly ("memory-safe") {
-            let free_mem_ptr := mload(0x40)
-            mstore(free_mem_ptr, RATES.slot)
-            let dataSlot := keccak256(free_mem_ptr, 0x20)
+            // The first 64 bytes of memory are scratch space.
+            // We use memory location 0x00 to store the slot of the mapping.
+            // See https://docs.soliditylang.org/en/latest/assembly.html
+            mstore(0x00, RATES.slot)
+            let dataSlot := keccak256(0x00, 0x20)
             value := sload(add(dataSlot, wordPos))
-            mstore(0x40, add(free_mem_ptr, 0x20))
         }
 
         uint256 shifted = uint256(value) >> ((24 - bytePos) * 8);

--- a/src/Conv.t.sol
+++ b/src/Conv.t.sol
@@ -20,6 +20,12 @@ import "forge-std/Test.sol";
 import "./Conv.sol";
 import "./mock/RatesMapping.sol";
 
+abstract contract StorageAddition {
+    uint256 a;
+}
+
+contract ModifiedConv is StorageAddition, Conv {}
+
 contract ConvTest is Test {
     Conv public conv;
     RatesMapping public ratesMapping;
@@ -35,9 +41,23 @@ contract ConvTest is Test {
     function testBtor() public view {
         for (uint256 bps = 0; bps <= maxBps; bps++) {
             uint256 mappingRate = ratesMapping.rates(bps);
-            uint256 bytesRate = conv.btor(bps);
+            uint256 convRate = conv.btor(bps);
 
-            assertEq(bytesRate, mappingRate, string.concat("Rate mismatch at bps=", vm.toString(bps)));
+            assertEq(convRate, mappingRate, string.concat("Rate mismatch at bps=", vm.toString(bps)));
+        }
+    }
+
+    function testBtorRatesInDifferentStorageSlot() public {
+        ModifiedConv modifiedConv = new ModifiedConv();
+        for (uint256 bps = 0; bps <= maxBps; bps++) {
+            uint256 mappingRate = ratesMapping.rates(bps);
+            uint256 convRate = modifiedConv.btor(bps);
+
+            assertEq(
+                convRate,
+                mappingRate,
+                string.concat("Rate mismatch with modified RATES storage position at bps=", vm.toString(bps))
+            );
         }
     }
 


### PR DESCRIPTION
There is an issue with line 

```
let dataSlot := keccak256(RATES.slot, 0x20)
```

The `keccak256(p, n)` opcode hashes `n` bytes from memory starting at position `p`. However, `RATES.slot` is a storage slot index, not a memory pointer.

When `RATES.slot` is 0, the code effectively computes `keccak256(0, 32)`, hashing the first 32 bytes of memory. This works by coincidence because that memory region is zeroed out, giving a predictable result. This is why the production version works, and there is no risk malfunction (Its storage layout cannot change after deployment).

If another state variable is added however, `RATES.slot` becomes 1. The code then computes `keccak256(1, 32)`, hashing memory from a different, unpredictable location. This results in an incorrect `dataSlot`, causing `sload` to read from the wrong storage address.

To fix this, the function was amended to compute the `keccak256` of the slot number itself. The approach is to store the slot number in memory and then hash that memory region.